### PR TITLE
Ability to provide the client_id to connect to the mqtt broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The configuration file is a JSON with the following content:
     "dev_id": "my-lumi-router",
     "mqtt_user": "",
     "mqtt_password": "",
-    "topic_root": "lumi/{MAC}",
+    "topic_root": "lumi/{dev-id}",
     "sensor_retain": false,
     "sensor_threshold": 50,
     "sensor_debounce_period": 60
@@ -32,7 +32,7 @@ The configuration file is a JSON with the following content:
 Every line is optional. By default, LumiMQTT will use the connection
 to localhost with the anonymous login.
 
-`{MAC}` will be automatically replaced by a hex number representing a MAC address.
+`{dev-id}` **if not provided** will be automatically replaced by a hex number representing a MAC address.
 
 `sensor_retain` is option to enable storing last sensor value on the broker
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The configuration file is a JSON with the following content:
 {
     "mqtt_host": "localhost",
     "mqtt_port": 1883,
-    "client_id": "my-lumi-router",
+    "dev_id": "my-lumi-router",
     "mqtt_user": "",
     "mqtt_password": "",
     "topic_root": "lumi/{MAC}",

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The configuration file is a JSON with the following content:
 {
     "mqtt_host": "localhost",
     "mqtt_port": 1883,
+    "client_id": "my-lumi-router",
     "mqtt_user": "",
     "mqtt_password": "",
     "topic_root": "lumi/{MAC}",

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The configuration file is a JSON with the following content:
     "dev_id": "my-lumi-router",
     "mqtt_user": "",
     "mqtt_password": "",
-    "topic_root": "lumi/{dev-id}",
+    "topic_root": "lumi/{dev_id}",
     "sensor_retain": false,
     "sensor_threshold": 50,
     "sensor_debounce_period": 60
@@ -32,7 +32,7 @@ The configuration file is a JSON with the following content:
 Every line is optional. By default, LumiMQTT will use the connection
 to localhost with the anonymous login.
 
-`{dev-id}` **if not provided** will be automatically replaced by a hex number representing a MAC address.
+`{dev_id}` **if not provided** will be automatically replaced by a hex number representing a MAC address.
 
 `sensor_retain` is option to enable storing last sensor value on the broker
 

--- a/lumimqtt.json.sample
+++ b/lumimqtt.json.sample
@@ -1,6 +1,6 @@
 {
     "mqtt_host": "localhost",
-    "client_id": "",
+    "dev_id": "",
     "mqtt_user": "",
     "mqtt_password": ""
 }

--- a/lumimqtt.json.sample
+++ b/lumimqtt.json.sample
@@ -1,6 +1,6 @@
 {
     "mqtt_host": "localhost",
-    "dev_id": "",
+    "dev_id": "my-lumi-router",
     "mqtt_user": "",
     "mqtt_password": ""
 }

--- a/lumimqtt.json.sample
+++ b/lumimqtt.json.sample
@@ -1,5 +1,6 @@
 {
     "mqtt_host": "localhost",
+    "client_id": "",
     "mqtt_user": "",
     "mqtt_password": ""
 }

--- a/lumimqtt/__main__.py
+++ b/lumimqtt/__main__.py
@@ -42,6 +42,7 @@ def main():
 
     dev_id = hex(get_mac())
     config = {
+        'client_id': dev_id,
         'topic_root': 'lumi/{MAC}',
         'mqtt_host': 'localhost',
         'mqtt_port': 1883,
@@ -63,7 +64,7 @@ def main():
     server = LumiMqtt(
         reconnection_interval=10,
         loop=loop,
-        dev_id=dev_id,
+        dev_id=config['client_id'],
         topic_root=config['topic_root'].replace('{MAC}', dev_id),
         host=config['mqtt_host'],
         port=config['mqtt_port'],

--- a/lumimqtt/__main__.py
+++ b/lumimqtt/__main__.py
@@ -42,7 +42,7 @@ def main():
 
     dev_id = hex(get_mac())
     config = {
-        'client_id': dev_id,
+        'dev_id': dev_id,
         'topic_root': 'lumi/{MAC}',
         'mqtt_host': 'localhost',
         'mqtt_port': 1883,
@@ -64,7 +64,7 @@ def main():
     server = LumiMqtt(
         reconnection_interval=10,
         loop=loop,
-        dev_id=config['client_id'],
+        dev_id=config['dev_id'],
         topic_root=config['topic_root'].replace('{MAC}', dev_id),
         host=config['mqtt_host'],
         port=config['mqtt_port'],

--- a/lumimqtt/__main__.py
+++ b/lumimqtt/__main__.py
@@ -43,7 +43,7 @@ def main():
     dev_id = hex(get_mac())
     config = {
         'dev_id': dev_id,
-        'topic_root': 'lumi/{MAC}',
+        'topic_root': 'lumi/{dev_id}',
         'mqtt_host': 'localhost',
         'mqtt_port': 1883,
         'sensor_threshold': 50,  # 5% of illuminance sensor
@@ -65,7 +65,7 @@ def main():
         reconnection_interval=10,
         loop=loop,
         dev_id=config['dev_id'],
-        topic_root=config['topic_root'].replace('{MAC}', dev_id),
+        topic_root=config['topic_root'].replace('{dev_id}', dev_id),
         host=config['mqtt_host'],
         port=config['mqtt_port'],
         user=config.get('mqtt_user'),


### PR DESCRIPTION
This is a work around to avoid that in each reboot it connects with a different client id to the mqtt broker. Helps with issue https://github.com/openlumi/lumimqtt/issues/13