### PR TITLE
Periodic publish

### DIFF
--- a/lumimqtt/__main__.py
+++ b/lumimqtt/__main__.py
@@ -51,7 +51,7 @@ def main():
         'sensor_threshold': 50,  # 5% of illuminance sensor
         'sensor_debounce_period': 60,  # 1 minute
         'light_transition_period': 1.0,  # second
-        'light_tele_period': 60, # 1 minute
+        'light_notification_period': 60, # 1 minute
         **config,
     }
 
@@ -72,7 +72,7 @@ def main():
         sensor_threshold=int(config['sensor_threshold']),
         sensor_debounce_period=int(config['sensor_debounce_period']),
         light_transition_period=float(config['light_transition_period']),
-        light_tele_period=float(config['light_tele_period']),
+        light_notification_period=float(config['light_notification_period']),
     )
 
     for device in devices(config.get('binary_sensors', {})):

--- a/lumimqtt/__main__.py
+++ b/lumimqtt/__main__.py
@@ -51,6 +51,7 @@ def main():
         'sensor_threshold': 50,  # 5% of illuminance sensor
         'sensor_debounce_period': 60,  # 1 minute
         'light_transition_period': 1.0,  # second
+        'light_tele_period': 60, # 1 minute
         **config,
     }
 
@@ -71,6 +72,7 @@ def main():
         sensor_threshold=int(config['sensor_threshold']),
         sensor_debounce_period=int(config['sensor_debounce_period']),
         light_transition_period=float(config['light_transition_period']),
+        light_tele_period=float(config['light_tele_period']),
     )
 
     for device in devices(config.get('binary_sensors', {})):

--- a/lumimqtt/lumimqtt.py
+++ b/lumimqtt/lumimqtt.py
@@ -42,7 +42,7 @@ class LumiMqtt:
             sensor_threshold: int,
             sensor_debounce_period: int,
             light_transition_period: float,
-            light_tele_period: float,
+            light_notification_period: float,
             loop: ty.Optional[aio.AbstractEventLoop] = None,
     ) -> None:
         self.dev_id = device_id
@@ -64,7 +64,7 @@ class LumiMqtt:
         self._sensor_threshold = sensor_threshold
         self._sensor_debounce_period = sensor_debounce_period
         self._light_transition_period = light_transition_period
-        self._light_tele_period = light_tele_period
+        self._light_notification_period = light_notification_period
         self._light_last_sent = None
 
         self._reconnection_interval = reconnection_interval
@@ -305,7 +305,7 @@ class LumiMqtt:
                     now = datetime.now()
                     should_send = (
                         self._light_last_sent is None or
-                        (now - self._light_last_sent).seconds >= self._light_tele_period
+                        (now - self._light_last_sent).seconds >= self._light_notification_period
                     )
                     if should_send:
                         await self._publish_light(light)

--- a/lumimqtt/lumimqtt.py
+++ b/lumimqtt/lumimqtt.py
@@ -320,8 +320,9 @@ class LumiMqtt:
 
             await aio.sleep(period)
 
-    async def _publish_sensor(self, sensor: Sensor, value=False):
-        value = value or sensor.get_value()
+    async def _publish_sensor(self, sensor: Sensor, value=None):
+        if value is None:
+            value = sensor.get_value()
         await self._client.publish(
             aio_mqtt.PublishableMessage(
                 topic_name=self._get_topic(sensor.topic),


### PR DESCRIPTION
The idea of this pull request is to improve periodic publishing to include lights, and also send the current state of light and sensor when connect/reconnect. This addresses #22 

Changes:
1. Refactor publishing of sensors and lights to a method each.
    - _publish_sensor
    - _publish_light

    Allowing to reuse in other parts of the code.

2. Refactor periodic publish to also publish lights state without
   repeating code. Implementing logic to send in the given tele period.

3. Addition on _connect_forever sending of sensor and light states after
   connecting. Therefore keeping the state in sync on reconnections.

If you agree with the changes I can update the readme to reflect this new configuration option. I'm willing to make the changes you consider appropriate in the code.