### PR TITLE
fix quote function in commands.py to work with non string argument

### DIFF
--- a/lumimqtt/commands.py
+++ b/lumimqtt/commands.py
@@ -38,7 +38,10 @@ class Command(Device):
 
     @staticmethod
     def quote(s):
-        return s.replace('"', '\\"').replace("'", "\\'").replace('$', '')
+        try:
+            return str(s).replace('"', '\\"').replace("'", "\\'").replace('$', '')
+        except:
+            return ""
 
     async def run_command(self, value):
         if isinstance(value, dict):


### PR DESCRIPTION
When called as given in example:
  Run command "tts_interpolate" | lumi/<ID>/tts_interpolate/set | {"text": "Hi, it is a test", "volume": 200}
in quote function in file commands.py error ocurres:
# LUMIMQTT_CONFIG=/etc/lumimqtt.json python3 -m lum
imqtt
INFO:__main__:Start lumimqtt 1.0.13
INFO:lumimqtt.lumimqtt:Connected to 10.1.1.20 with client id 'lumimqtt_0x38839a66bb7d'
INFO:lumimqtt.lumimqtt:Wait for network interruptions...
INFO:lumimqtt.commands:tts_interpolate: run command with params: {'text': 'Hi, it is a test', 'volume': 200}
ERROR:lumimqtt.lumimqtt:Unhandled exception during echo message publishing
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/lumimqtt/lumimqtt.py", line 188, in _handle_messages
    await command.set(value)
  File "/usr/lib/python3.7/site-packages/lumimqtt/commands.py", line 64, in set
    await self.run_command(value)
  File "/usr/lib/python3.7/site-packages/lumimqtt/commands.py", line 47, in run_command
    for k, v in value.items()
  File "/usr/lib/python3.7/site-packages/lumimqtt/commands.py", line 47, in <dictcomp>
    for k, v in value.items()
  File "/usr/lib/python3.7/site-packages/lumimqtt/commands.py", line 41, in quote
    return s.replace('"', '\\"').replace("'", "\\'").replace('$', '')
AttributeError: 'int' object has no attribute 'replace'

This should be fix for this using str() and try...except
Please merge.


