### PR TITLE
Remove deprecated flag "color_mode"

### DIFF
--- a/lumimqtt/lumimqtt.py
+++ b/lumimqtt/lumimqtt.py
@@ -317,7 +317,6 @@ class LumiMqtt:
                     payload=json.dumps({
                         **get_generic_vals(light.name),
                         'schema': 'json',
-                        'color_mode': True,
                         'supported_color_modes': [light.COLOR_MODE],
                         'brightness': light.BRIGHTNESS,
                         'state_topic': self._get_topic(light.topic),


### PR DESCRIPTION
Fix warnings:
```
2024-09-15 14:58:00.441 WARNING (MainThread) [homeassistant.components.mqtt.light.schema_json] Deprecated flag `color_mode` used in MQTT JSON light config , the `color_mode` flag is not used anymore and should be removed. Got: {'unique_id': 'light_123', 'device': {'identifiers': ['xiaomi_gateway_0x123'], 'sw_version': '1.0.16', 'model': 'Xiaomi Gateway', 'manufacturer': 'Xiaomi', 'name': 'xiaomi_gateway_123'}, 'availability_topic': 'hallway/gateway/status', 'schema': 'json', 'color_mode': True, 'supported_color_modes': ['rgb'], 'brightness': True, 'state_topic': 'hallway/gateway/light', 'command_topic': 'hallway/gateway/light/set', 'name': 'light_123', 'platform': 'mqtt'}. This will stop working in Home Assistant Core 2025.3
```